### PR TITLE
update falco version and add junk macros

### DIFF
--- a/falco/resources/Chart.yaml
+++ b/falco/resources/Chart.yaml
@@ -1,7 +1,7 @@
 apiVersion: v2
-version: v0.0.2
+version: v0.38.1
 name: falco
 dependencies:
 - name: falco
-  version: 1.11.1
+  version: 4.6.0
   repository: https://falcosecurity.github.io/charts

--- a/falco/resources/values.yaml
+++ b/falco/resources/values.yaml
@@ -20,9 +20,15 @@ falco:
         - /etc/falco/rules.d/custom-rules.yaml
     customRules:
       custom-rules.yaml: |-
+        - macro: rename_cust
+          condition: evt.type in (rename, renameat)
+        - macro: remove_cust
+          condition: evt.type in (rmdir, unlink, unlinkat)
+        - macro: modify_cust
+          condition: rename_cust or remove_cust
         - rule: COOKIE tampering detector
           desc: Detect tampering of super precious cookie recipes
-          condition: modify and (evt.arg.oldpath startswith '/usr/share/nginx' or evt.arg.path startswith '/usr/share/nginx')
+          condition: modify_cust and (evt.arg.oldpath startswith '/usr/share/nginx' or evt.arg.path startswith '/usr/share/nginx')
           output: Cookie recipes tampering detected, secure your cookies,(uid=%user.uid container_id=%container.id container_name=%container.name image=%container.image.repository:%container.image.tag %evt.arg.oldpath)
           priority: EMERGENCY
           tags: [importantrecipesalert]


### PR DESCRIPTION
the version of falco is too old, so it gets a 404 error downloading driver, upgraded falco chart/app version, which introduced an undefined macro, added dummy macro to replace, there is probably a cleaner solution for the macro...